### PR TITLE
Build GluonUIKit on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 script:
 - swiftformat --lint --verbose .
 - swiftlint
+- xcodebuild -scheme GluonUIKit -sdk iphonesimulator
 - xcodebuild test -enableCodeCoverage YES -scheme GluonCore
 after_success:
 - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This makes CI track build errors in `GluonUIKit` module, which previously could be missed.